### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Protobuf CI
 A collection of actions and reusable workflows for CI testing in Protobuf
 repositories.

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -37,24 +37,46 @@ runs:
   using: 'composite'
   steps:
     - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
       run: |
-        # validate subscription status
-        API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+        UPSTREAM="protocolbuffers/protobuf-ci"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        # Set a timeout for the curl command (3 seconds)
-        RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-        CURL_EXIT_CODE=$?
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
 
-        # Decide based on curl exit code and HTTP status
-        if [ $CURL_EXIT_CODE -ne 0 ]; then
-          echo "Timeout or API not reachable. Continuing to next step."
-        elif [ "$RESPONSE" = "200" ]; then
-          :
-        elif [ "$RESPONSE" = "403" ]; then
-          echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-          exit 1
-        else
-          echo "Timeout or API not reachable. Continuing to next step."
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
         fi
       shell: bash
 

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -48,24 +48,46 @@ runs:
   using: 'composite'
   steps:
     - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
       run: |
-        # validate subscription status
-        API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+        UPSTREAM="protocolbuffers/protobuf-ci"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        # Set a timeout for the curl command (3 seconds)
-        RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-        CURL_EXIT_CODE=$?
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
 
-        # Decide based on curl exit code and HTTP status
-        if [ $CURL_EXIT_CODE -ne 0 ]; then
-          echo "Timeout or API not reachable. Continuing to next step."
-        elif [ "$RESPONSE" = "200" ]; then
-          :
-        elif [ "$RESPONSE" = "403" ]; then
-          echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-          exit 1
-        else
-          echo "Timeout or API not reachable. Continuing to next step."
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
         fi
       shell: bash
 

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -55,24 +55,46 @@ runs:
   using: 'composite'
   steps:
     - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
       run: |
-        # validate subscription status
-        API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+        UPSTREAM="protocolbuffers/protobuf-ci"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        # Set a timeout for the curl command (3 seconds)
-        RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-        CURL_EXIT_CODE=$?
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
 
-        # Decide based on curl exit code and HTTP status
-        if [ $CURL_EXIT_CODE -ne 0 ]; then
-          echo "Timeout or API not reachable. Continuing to next step."
-        elif [ "$RESPONSE" = "200" ]; then
-          :
-        elif [ "$RESPONSE" = "403" ]; then
-          echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-          exit 1
-        else
-          echo "Timeout or API not reachable. Continuing to next step."
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
         fi
       shell: bash
 

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -43,24 +43,46 @@ runs:
   using: 'composite'
   steps:
     - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
       run: |
-        # validate subscription status
-        API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+        UPSTREAM="protocolbuffers/protobuf-ci"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        # Set a timeout for the curl command (3 seconds)
-        RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-        CURL_EXIT_CODE=$?
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
 
-        # Decide based on curl exit code and HTTP status
-        if [ $CURL_EXIT_CODE -ne 0 ]; then
-          echo "Timeout or API not reachable. Continuing to next step."
-        elif [ "$RESPONSE" = "200" ]; then
-          :
-        elif [ "$RESPONSE" = "403" ]; then
-          echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-          exit 1
-        else
-          echo "Timeout or API not reachable. Continuing to next step."
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
         fi
       shell: bash
 

--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -27,24 +27,46 @@ runs:
   using: 'composite'
   steps:
     - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
       run: |
-        # validate subscription status
-        API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+        UPSTREAM="protocolbuffers/protobuf-ci"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        # Set a timeout for the curl command (3 seconds)
-        RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-        CURL_EXIT_CODE=$?
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
 
-        # Decide based on curl exit code and HTTP status
-        if [ $CURL_EXIT_CODE -ne 0 ]; then
-          echo "Timeout or API not reachable. Continuing to next step."
-        elif [ "$RESPONSE" = "200" ]; then
-          :
-        elif [ "$RESPONSE" = "403" ]; then
-          echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-          exit 1
-        else
-          echo "Timeout or API not reachable. Continuing to next step."
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
         fi
       shell: bash
 

--- a/composer-setup/action.yml
+++ b/composer-setup/action.yml
@@ -28,24 +28,46 @@ runs:
   using: 'composite'
   steps:
     - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
       run: |
-        # validate subscription status
-        API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+        UPSTREAM="protocolbuffers/protobuf-ci"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        # Set a timeout for the curl command (3 seconds)
-        RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-        CURL_EXIT_CODE=$?
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
 
-        # Decide based on curl exit code and HTTP status
-        if [ $CURL_EXIT_CODE -ne 0 ]; then
-          echo "Timeout or API not reachable. Continuing to next step."
-        elif [ "$RESPONSE" = "200" ]; then
-          :
-        elif [ "$RESPONSE" = "403" ]; then
-          echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-          exit 1
-        else
-          echo "Timeout or API not reachable. Continuing to next step."
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
         fi
       shell: bash
 

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -37,24 +37,46 @@ runs:
   using: 'composite'
   steps:
     - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
       run: |
-        # validate subscription status
-        API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+        UPSTREAM="protocolbuffers/protobuf-ci"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        # Set a timeout for the curl command (3 seconds)
-        RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-        CURL_EXIT_CODE=$?
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
 
-        # Decide based on curl exit code and HTTP status
-        if [ $CURL_EXIT_CODE -ne 0 ]; then
-          echo "Timeout or API not reachable. Continuing to next step."
-        elif [ "$RESPONSE" = "200" ]; then
-          :
-        elif [ "$RESPONSE" = "403" ]; then
-          echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-          exit 1
-        else
-          echo "Timeout or API not reachable. Continuing to next step."
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
         fi
       shell: bash
 

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -53,24 +53,46 @@ runs:
   using: 'composite'
   steps:
     - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
       run: |
-        # validate subscription status
-        API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+        UPSTREAM="protocolbuffers/protobuf-ci"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        # Set a timeout for the curl command (3 seconds)
-        RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-        CURL_EXIT_CODE=$?
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
 
-        # Decide based on curl exit code and HTTP status
-        if [ $CURL_EXIT_CODE -ne 0 ]; then
-          echo "Timeout or API not reachable. Continuing to next step."
-        elif [ "$RESPONSE" = "200" ]; then
-          :
-        elif [ "$RESPONSE" = "403" ]; then
-          echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-          exit 1
-        else
-          echo "Timeout or API not reachable. Continuing to next step."
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
         fi
       shell: bash
 

--- a/sccache/action.yml
+++ b/sccache/action.yml
@@ -34,24 +34,46 @@ runs:
   using: 'composite'
   steps:
     - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
       run: |
-        # validate subscription status
-        API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+        UPSTREAM="protocolbuffers/protobuf-ci"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        # Set a timeout for the curl command (3 seconds)
-        RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-        CURL_EXIT_CODE=$?
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
 
-        # Decide based on curl exit code and HTTP status
-        if [ $CURL_EXIT_CODE -ne 0 ]; then
-          echo "Timeout or API not reachable. Continuing to next step."
-        elif [ "$RESPONSE" = "200" ]; then
-          :
-        elif [ "$RESPONSE" = "403" ]; then
-          echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-          exit 1
-        else
-          echo "Timeout or API not reachable. Continuing to next step."
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
         fi
       shell: bash
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Applied to all 9 composite actions: bash, bazel, bazel-docker, ccache, checkout, composer-setup, cross-compile-protoc, docker, sccache

## Changes by type
- **Composite actions**: replaced Subscription check step in each action.yml with the new banner + public-repo-free logic that hits `maintained-actions-subscription` only for private repos
- **README**: prepended StepSecurity Maintained Action banner

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z